### PR TITLE
Remove workaround

### DIFF
--- a/EDA-2763/flop_by_pll/top.v
+++ b/EDA-2763/flop_by_pll/top.v
@@ -1,7 +1,7 @@
 module top(
-	input wire clk,
+  input wire clk,
   input wire [7:0] din,
-	output reg [7:0] dout
+  output reg [7:0] dout
 );
   wire [7:0] pllclk;
   PLL #(

--- a/EDA-2763/flop_by_pll/top.v
+++ b/EDA-2763/flop_by_pll/top.v
@@ -3,16 +3,7 @@ module top(
   input wire [7:0] din,
 	output reg [7:0] dout
 );
-  wire clkbuf;
   wire [7:0] pllclk;
-  /*
-    CLK_BUF is workaround - expect auto-inserted
-  */
-  CLK_BUF clk_buf 
-  (
-    .I(clk),
-    .O(clkbuf)
-  );
   PLL #(
     .DIVIDE_CLK_IN_BY_2("FALSE"),
     .PLL_MULT(16),
@@ -20,7 +11,7 @@ module top(
     .PLL_POST_DIV(34)
   ) pll_pin (
     .PLL_EN(1'b1),
-    .CLK_IN(clkbuf),
+    .CLK_IN(clk),
     .CLK_OUT(pllclk[0]),
     .CLK_OUT_DIV2(pllclk[1]),
     .CLK_OUT_DIV3(pllclk[2]),


### PR DESCRIPTION
Verified https://rapidsilicon.atlassian.net/browse/EDA-2907

We could remove the workaround now. 