### PR TITLE
Add clock_as_data but with auto-infer support

### DIFF
--- a/EDA-2763/clock_as_data_auto_infer/top.sdc
+++ b/EDA-2763/clock_as_data_auto_infer/top.sdc
@@ -1,0 +1,5 @@
+set_pin_loc clk HP_1_CC_18_9P
+
+set_pin_loc din HP_1_0_0P
+
+set_pin_loc dout HP_1_1_0N

--- a/EDA-2763/clock_as_data_auto_infer/top.v
+++ b/EDA-2763/clock_as_data_auto_infer/top.v
@@ -1,0 +1,11 @@
+module top (
+  input wire clk,
+  input wire din,
+  output wire dout
+);
+  reg temp;
+  always @(posedge clk) begin
+    temp <= din;
+  end
+  assign dout = temp & clk;
+endmodule


### PR DESCRIPTION
This is exact same design as "clock_as_data", where the difference is
- "clock_as_data" - all primitives are manually instansiated 
- this new "clock_as_data_auto_infer" let the synthesis do the auto-infer of primitives.